### PR TITLE
feat: add support for Private in IPAddressSpace

### DIFF
--- a/network/types.go
+++ b/network/types.go
@@ -1663,6 +1663,7 @@ const (
 	IPAddressSpaceLocal    IPAddressSpace = "Local"
 	IPAddressSpacePublic   IPAddressSpace = "Public"
 	IPAddressSpaceUnknown  IPAddressSpace = "Unknown"
+	IPAddressSpacePrivate  IPAddressSpace = "Private"
 )
 
 // UnmarshalJSON satisfies [json.Unmarshaler].
@@ -1679,6 +1680,8 @@ func (t *IPAddressSpace) UnmarshalJSON(buf []byte) error {
 		*t = IPAddressSpacePublic
 	case IPAddressSpaceUnknown:
 		*t = IPAddressSpaceUnknown
+	case IPAddressSpacePrivate:
+		*t = IPAddressSpacePrivate
 	default:
 		return fmt.Errorf("unknown IPAddressSpace value: %v", s)
 	}


### PR DESCRIPTION
### 问题概述
在使用 chromedp 监听 `network.EventRequestWillBeSentExtraInfo` 时，Go 程序解析事件失败，报错如下：

ERROR: could not unmarshal event: json: cannot unmarshal JSON string into Go network.IPAddressSpace within "/clientSecurityState/initiatorIPAddressSpace": unknown IPAddressSpace value: Private

### 环境信息
- Chrome 版本: 139.0.7258.66 (Official Build) (64-bit)
- Go 版本: 1.21+（或你的版本）
- chromedp 版本: v0.14.1
- cdproto 版本: v0.0.0-20250803210736-d308e07a266d
- 操作系统: Linux / macOS / Windows (根据实际填写)

### 问题原因
- Chrome 在新版本中，在 `/clientSecurityState/initiatorIPAddressSpace` 字段可能返回 `"Private"` 值。  
- 当前 cdproto `network.IPAddressSpace` 枚举只支持 `"Local"`, `"Public"`, `"Unknown"`，因此 JSON 解码失败。

### 复现步骤
1. 使用 chromedp 监听 `network.EventRequestWillBeSentExtraInfo`。
2. 在请求触发时，Chrome 返回 `"Private"` 的 `initiatorIPAddressSpace`。
3. Go JSON 解码时报错 `unknown IPAddressSpace value: Private`。

### 建议解决方案
- 在 `cdproto/network/ipaddressspace.go` 添加 `IPAddressSpacePrivate = "Private"` 枚举值。
- 在 `UnmarshalJSON` 中处理 `"Private"`，或使用防御性编程直接接受未知值。